### PR TITLE
fix issue with path resolution on windows systems

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -8,7 +8,7 @@ var resolve = require('./resolve');
 function Sandbox(root, options) {
   if (!options) options = {};
 
-  if (root.slice(-1) !== '/') root += '/';
+  if (root.slice(-1) !== path.sep) root += path.sep;
 
   this.root = root;
   this.modules = {};


### PR DESCRIPTION
since windows systems use "\" as a path separator, doing a hard check for "/" will cause unintended results in windows. Using "path.sep" which is a platform specific check, solves this issue.
